### PR TITLE
Only set BINDIR when not already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,14 @@ EXE=csvquote
 EXTRA=csvheader
 CFLAGS=-Wall -g
 
-BINDIR=/usr/local/bin
-
 all:	$(EXE)
 
 $(EXE):
 	$(CC) $(CFLAGS) $(EXE).c -o $(EXE)
 
 install: $(EXE) $(EXTRA)
-	install -m 755 $(EXE) $(BINDIR)
-	install -m 755 $(EXTRA) $(BINDIR)
+	install -m 755 $(EXE) $(PREFIX)
+	install -m 755 $(EXTRA) $(PREFIX)
 
 clean:
 	rm -f $(EXE)

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,16 @@ EXE=csvquote
 EXTRA=csvheader
 CFLAGS=-Wall -g
 
+BINDIR?=/usr/local/bin
+
 all:	$(EXE)
 
 $(EXE):
 	$(CC) $(CFLAGS) $(EXE).c -o $(EXE)
 
 install: $(EXE) $(EXTRA)
-	install -m 755 $(EXE) $(PREFIX)
-	install -m 755 $(EXTRA) $(PREFIX)
+	install -m 755 $(EXE) $(BINDIR)
+	install -m 755 $(EXTRA) $(BINDIR)
 
 clean:
 	rm -f $(EXE)


### PR DESCRIPTION
Do you mind merging this simple change?  This will make it possible to set a BINDIR env var to override the /usr/local/bin default value.

I've been maintaining a homebrew (sschlesier/csvutils/csvquote) formula, this change would allow the formula to work without any code differences.  Then the only difference between the canonical repo and my fork will be the git tags used to make homebrew versioning work smoothly.