### PR TITLE
add homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ of data.
 
 Depends on the "build-essentials" package.
 
+### via Homebrew (Mac, Linux)
+
+    $ brew install sschlesier/csvutils/csvquote
+
 Known limitations
 -----------------
 


### PR DESCRIPTION
I noticed you closed an issue asking for a hombres install recently.  Here is a quick addition to the install instructions if you would like to include homebrew as an option.

BTW, if you were willing to add tags e.g. v0.1.5 is my current version, I wouldn't even need to fork this repo.  But no problem if you aren't interested.  This changes rarely enough that I can easily keep up with updating the fork.